### PR TITLE
Fix kube-linter issues

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -34,5 +34,16 @@ spec:
                   name: exporters-secret
                   key: pager-duty-token
                   optional: false
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: dora-metrics-exporter-sa
       serviceAccount: dora-metrics-exporter-sa


### PR DESCRIPTION
Fix kube-linter issues for dora-metrics pods/containers:

* Set runAsNonRoot and readOnlyRootFilesystem to true.
* Set resources requests and limits.