### PR TITLE
feat: monitor all argocd as per request from architects

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,8 +45,10 @@ func main() {
 
 	if cfg.ArgoCD.Enabled {
 		logger.Infof("ArgoCD monitoring: enabled (namespaces: %v)", cfg.ArgoCD.Namespaces)
-		if len(cfg.ArgoCD.ComponentsToMonitor) > 0 {
-			logger.Infof("ArgoCD components to monitor: %v", cfg.ArgoCD.ComponentsToMonitor)
+		if len(cfg.ArgoCD.ComponentsToIgnore) > 0 {
+			logger.Infof("ArgoCD components to ignore: %v", cfg.ArgoCD.ComponentsToIgnore)
+		} else {
+			logger.Infof("ArgoCD monitoring: all components will be monitored")
 		}
 		if len(cfg.ArgoCD.KnownClusters) > 0 {
 			logger.Infof("ArgoCD known clusters: %v", cfg.ArgoCD.KnownClusters)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -16,31 +16,11 @@ argocd:
   namespaces:
     - konflux-public-production
     - argocd
-  # List of components to monitor across all known clusters
-  # These will be combined with known_clusters to generate full application names
-  # Format: component-name (e.g., "build-service", "pulp-access-controller")
-  components_to_monitor:
-    - build-service
-    - crossplane-control-plane
-    - dora-metrics
-    - enterprise-contract
-    - etcd-defrag
-    - etcd-shield
-    - image-controller
-    - integration
-    - internal-services
-    - konflux-info
-    - konflux-ui
-    - kubelet-config
-    - kueue
-    - kyverno
-    - mintmaker
-    - multi-platform-controller
-    - namespace-lister
-    - notification-controller
-    - project-controller
-    - release
-    - smee-client
+  # List of components to ignore (all other components will be monitored)
+  # These components will be excluded from monitoring across all known clusters
+  # Format: component-name (e.g., "test-component", "deprecated-service")
+  # Leave empty to monitor all components
+  components_to_ignore: []
 
   # Known cluster names for application name parsing
   # These are used to extract component and cluster information from application names

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,7 +121,9 @@ The system tracks all four DORA metrics:
 argocd:
   enabled: true
   namespaces: ["argocd", "openshift-gitops"]
-  componentsToMonitor: ["konflux-ui", "konflux-api"]
+  componentsToIgnore: []
+  # List components to exclude from monitoring (all others will be monitored)
+  # Example: ["test-component", "deprecated-service"]
   knownClusters: ["production", "staging"]
 
 integration:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,9 +230,9 @@ argocd:
   namespaces:
     - "argocd"
     - "openshift-gitops"
-  componentsToMonitor:
-    - "konflux-ui"
-    - "konflux-api"
+  componentsToIgnore: []
+  # List components to exclude from monitoring (all others will be monitored)
+  # Example: ["test-component", "deprecated-service"]
   knownClusters:
     - "production"
     - "staging"

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -94,10 +94,9 @@ data:
       namespaces:
         - "argocd"
         - "openshift-gitops"
-      componentsToMonitor:
-        - "konflux-ui"
-        - "konflux-api"
-        - "konflux-backend"
+      componentsToIgnore: []
+      # List components to exclude from monitoring (all others will be monitored)
+      # Example: ["test-component", "deprecated-service"]
       knownClusters:
         - "production"
         - "staging"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,8 +76,8 @@ func LoadWithFlags(flgs Flags) *Config {
 	// ArgoCD namespaces from YAML only - no defaults
 	argocdNamespaces := yamlConfig.ArgoCD.Namespaces
 
-	// ArgoCD components to monitor from YAML only
-	argocdComponentsToMonitor := yamlConfig.ArgoCD.ComponentsToMonitor
+	// ArgoCD components to ignore from YAML only
+	argocdComponentsToIgnore := yamlConfig.ArgoCD.ComponentsToIgnore
 
 	// ArgoCD known clusters from YAML only - no defaults
 	argocdKnownClusters := yamlConfig.ArgoCD.KnownClusters
@@ -142,10 +142,10 @@ func LoadWithFlags(flgs Flags) *Config {
 			Interval: webrcaInterval,
 		},
 		ArgoCD: ArgoCDConfig{
-			Enabled:             argocdEnabled,
-			Namespaces:          argocdNamespaces,
-			ComponentsToMonitor: argocdComponentsToMonitor,
-			KnownClusters:       argocdKnownClusters,
+			Enabled:           argocdEnabled,
+			Namespaces:        argocdNamespaces,
+			ComponentsToIgnore: argocdComponentsToIgnore,
+			KnownClusters:     argocdKnownClusters,
 		},
 		Storage: StorageConfig{
 			Redis: RedisYAMLConfig{

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -86,9 +86,9 @@ type ArgoCDConfig struct {
 	// Kubernetes namespaces to watch (e.g., ["argocd", "production"])
 	Namespaces []string
 
-	// Components to monitor (e.g., ["build-service", "pulp-access-controller"])
-	// These will be combined with known_clusters to generate full application names
-	ComponentsToMonitor []string
+	// Components to ignore (all other components will be monitored)
+	// These components will be excluded from monitoring across all known clusters
+	ComponentsToIgnore []string
 
 	// Known cluster names for parsing (e.g., ["kflux-ocp-p01", "pentest-p01"])
 	KnownClusters []string
@@ -104,9 +104,9 @@ type ArgoCDYAMLConfig struct {
 	// Kubernetes namespaces to watch (e.g., ["argocd", "production"])
 	Namespaces []string `yaml:"namespaces"`
 
-	// Components to monitor (e.g., ["build-service", "pulp-access-controller"])
-	// These will be combined with known_clusters to generate full application names
-	ComponentsToMonitor []string `yaml:"components_to_monitor"`
+	// Components to ignore (all other components will be monitored)
+	// These components will be excluded from monitoring across all known clusters
+	ComponentsToIgnore []string `yaml:"components_to_ignore"`
 
 	// Known cluster names for parsing (e.g., ["kflux-ocp-p01", "pentest-p01"])
 	KnownClusters []string `yaml:"known_clusters"`

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -13,13 +13,13 @@ import (
 // SetupRoutes configures all HTTP routes for the DORA Metrics Server.
 // It registers API endpoints for health checks and other services using the API machinery pattern.
 // This function should be called during server initialization.
-func SetupRoutes(app *fiber.App, argocdClient *argocdclient.Clientset, argocdNamespaces, argocdComponentsToMonitor, argocdKnownClusters []string) {
+func SetupRoutes(app *fiber.App, argocdClient *argocdclient.Clientset, argocdNamespaces, argocdComponentsToIgnore, argocdKnownClusters []string) {
 	// Register all APIs here - just add one line per API
 	health.RegisterRoutes(app)
 
 	// Register ArgoCD API if client is available
 	if argocdClient != nil {
-		argocdHandler, err := argocd.NewHandler(argocdClient, argocdNamespaces, argocdComponentsToMonitor, argocdKnownClusters)
+		argocdHandler, err := argocd.NewHandler(argocdClient, argocdNamespaces, argocdComponentsToIgnore, argocdKnownClusters)
 		if err != nil {
 			// Log error but continue - ArgoCD API will not be available
 			// The error is already logged in NewHandler

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,10 +81,10 @@ func New(cfg *config.Config) *Server {
 	var argocdClient *argocdclient.Clientset
 	if cfg.ArgoCD.Enabled {
 		argocdConfig := &argocdmonitor.Config{
-			Enabled:             cfg.ArgoCD.Enabled,
-			Namespaces:          cfg.ArgoCD.Namespaces,
-			ComponentsToMonitor: cfg.ArgoCD.ComponentsToMonitor,
-			KnownClusters:       cfg.ArgoCD.KnownClusters,
+			Enabled:           cfg.ArgoCD.Enabled,
+			Namespaces:        cfg.ArgoCD.Namespaces,
+			ComponentsToIgnore: cfg.ArgoCD.ComponentsToIgnore,
+			KnownClusters:     cfg.ArgoCD.KnownClusters,
 		}
 
 		argocdMonitorClient, err := argocdmonitor.CreateArgoCDClient(argocdConfig)
@@ -98,7 +98,7 @@ func New(cfg *config.Config) *Server {
 	}
 
 	// Setup routes
-	handlers.SetupRoutes(app, argocdClient, cfg.ArgoCD.Namespaces, cfg.ArgoCD.ComponentsToMonitor, cfg.ArgoCD.KnownClusters)
+	handlers.SetupRoutes(app, argocdClient, cfg.ArgoCD.Namespaces, cfg.ArgoCD.ComponentsToIgnore, cfg.ArgoCD.KnownClusters)
 
 	// Initialize storage client if enabled
 	var storageClient *storage.RedisClient
@@ -148,10 +148,10 @@ func New(cfg *config.Config) *Server {
 		argocdmonitor.SetKnownClusters(cfg.ArgoCD.KnownClusters)
 
 		argocdConfig := &argocdmonitor.Config{
-			Enabled:             cfg.ArgoCD.Enabled,
-			Namespaces:          cfg.ArgoCD.Namespaces,
-			ComponentsToMonitor: cfg.ArgoCD.ComponentsToMonitor,
-			KnownClusters:       cfg.ArgoCD.KnownClusters,
+			Enabled:           cfg.ArgoCD.Enabled,
+			Namespaces:        cfg.ArgoCD.Namespaces,
+			ComponentsToIgnore: cfg.ArgoCD.ComponentsToIgnore,
+			KnownClusters:     cfg.ArgoCD.KnownClusters,
 		}
 
 		// Create ArgoCD monitor with storage client

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -26,28 +26,9 @@ data:
       namespaces:
         - konflux-public-production
         - argocd
-      components_to_monitor:
-        - build-service
-        - crossplane-control-plane
-        - dora-metrics
-        - enterprise-contract
-        - etcd-defrag
-        - etcd-shield
-        - image-controller
-        - integration
-        - internal-services
-        - konflux-info
-        - konflux-ui
-        - kubelet-config
-        - kueue
-        - kyverno
-        - mintmaker
-        - multi-platform-controller
-        - namespace-lister
-        - notification-controller
-        - project-controller
-        - release
-        - smee-client
+      # List of components to ignore (all other components will be monitored)
+      # Leave empty to monitor all components
+      components_to_ignore: []
       known_clusters:
         - kflux-ocp-p01
         - kflux-osp-p01

--- a/pkg/monitors/argocd/api/types.go
+++ b/pkg/monitors/argocd/api/types.go
@@ -22,8 +22,9 @@ type Config struct {
 	// Namespaces lists Kubernetes namespaces to watch for ArgoCD applications
 	Namespaces []string `json:"namespaces"`
 
-	// ComponentsToMonitor lists component names to monitor across all clusters
-	ComponentsToMonitor []string `json:"components_to_monitor"`
+	// ComponentsToIgnore lists component names to exclude from monitoring
+	// All other components will be monitored across all clusters
+	ComponentsToIgnore []string `json:"components_to_ignore"`
 
 	// KnownClusters lists known cluster names for parsing application names
 	KnownClusters []string `json:"known_clusters"`

--- a/pkg/monitors/argocd/parser/application.go
+++ b/pkg/monitors/argocd/parser/application.go
@@ -66,8 +66,8 @@ func (p *ApplicationParser) ShouldMonitor(app *v1alpha1.Application) bool {
 	// Parse application name to get component and cluster
 	_, component, cluster := p.parseApplicationName(app.Name)
 
-	// Check if component should be monitored
-	if !p.isComponentMonitored(component) {
+	// Check if component should be ignored
+	if p.isComponentIgnored(component) {
 		return false
 	}
 
@@ -124,10 +124,17 @@ func (p *ApplicationParser) isNamespaceMonitored(namespace string) bool {
 	return false
 }
 
-// isComponentMonitored checks if a component should be monitored.
-func (p *ApplicationParser) isComponentMonitored(component string) bool {
-	for _, comp := range p.config.ComponentsToMonitor {
-		if comp == component {
+// isComponentIgnored checks if a component should be ignored (not monitored).
+// Returns true if the component is in the ignore list, false otherwise.
+// By default, all components are monitored unless they are in the ignore list.
+func (p *ApplicationParser) isComponentIgnored(component string) bool {
+	// If component is empty, don't ignore it (let other checks handle it)
+	if component == "" {
+		return false
+	}
+	// Check if component is in the ignore list
+	for _, ignoredComp := range p.config.ComponentsToIgnore {
+		if ignoredComp == component {
 			return true
 		}
 	}


### PR DESCRIPTION
Instead of puting manually all the components to monitor is better just to allow users to ignore fews.