### PR TITLE
fix: detect environment from source path and make deployment IDs clus…

### DIFF
--- a/pkg/monitors/argocd/parser/application.go
+++ b/pkg/monitors/argocd/parser/application.go
@@ -39,8 +39,11 @@ func (p *ApplicationParser) ParseApplication(app *v1alpha1.Application) (*api.Ap
 		Images:     p.extractImagesFromStatus(&app.Status),
 	}
 
-	// Parse environment, component, and cluster from application name
-	appInfo.Environment, appInfo.Component, appInfo.Cluster = p.parseApplicationName(app.Name)
+	// Parse component and cluster from application name
+	_, appInfo.Component, appInfo.Cluster = p.parseApplicationName(app.Name)
+
+	// Extract environment from source path (e.g., "components/build-service/production/" -> "production")
+	appInfo.Environment = p.extractEnvironmentFromSourcePath(app)
 
 	return appInfo, nil
 }
@@ -90,6 +93,7 @@ func (p *ApplicationParser) extractImagesFromStatus(status *v1alpha1.Application
 }
 
 // parseApplicationName parses application name to extract environment, component, and cluster.
+// Environment is now extracted from source path, not application name.
 func (p *ApplicationParser) parseApplicationName(name string) (string, string, string) {
 	// Find cluster suffix
 	var cluster string
@@ -108,10 +112,55 @@ func (p *ApplicationParser) parseApplicationName(name string) (string, string, s
 	nameWithoutCluster := strings.TrimSuffix(name, "-"+cluster)
 	component := nameWithoutCluster
 
-	// For now, set environment to "production" since we don't have environment info in the name
-	environment := "production"
+	// Environment is extracted separately from source path
+	return "", component, cluster
+}
 
-	return environment, component, cluster
+// extractEnvironmentFromSourcePath extracts the environment from the ArgoCD source path.
+// Expected path format: "components/<component>/<environment>/" or similar patterns.
+// Returns uppercase environment for DevLake compatibility (PRODUCTION, STAGING, DEVELOPMENT).
+func (p *ApplicationParser) extractEnvironmentFromSourcePath(app *v1alpha1.Application) string {
+	sourcePath := app.Spec.Source.Path
+	if sourcePath == "" {
+		return "PRODUCTION" // Default fallback
+	}
+
+	// Normalize path separators and convert to lowercase for matching
+	path := strings.ToLower(sourcePath)
+
+	// Check for known environment patterns in the path
+	// Patterns: /production/, /staging/, /development/, /dev/, /stage/, /prod/
+	environmentMappings := map[string]string{
+		"/production/":  "PRODUCTION",
+		"/prod/":        "PRODUCTION",
+		"/staging/":     "STAGING",
+		"/stage/":       "STAGING",
+		"/development/": "DEVELOPMENT",
+		"/dev/":         "DEVELOPMENT",
+	}
+
+	for pattern, env := range environmentMappings {
+		if strings.Contains(path, pattern) {
+			return env
+		}
+	}
+
+	// Also check for environment at the end of path (without trailing slash)
+	pathParts := strings.Split(strings.Trim(sourcePath, "/"), "/")
+	if len(pathParts) > 0 {
+		lastPart := strings.ToLower(pathParts[len(pathParts)-1])
+		switch lastPart {
+		case "production", "prod":
+			return "PRODUCTION"
+		case "staging", "stage":
+			return "STAGING"
+		case "development", "dev":
+			return "DEVELOPMENT"
+		}
+	}
+
+	// Default to PRODUCTION if no environment pattern found
+	return "PRODUCTION"
 }
 
 // isNamespaceMonitored checks if a namespace should be monitored.

--- a/pkg/monitors/argocd/parser/formatter.go
+++ b/pkg/monitors/argocd/parser/formatter.go
@@ -6,6 +6,7 @@ package parser
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/redhat-appstudio/dora-metrics/pkg/integrations"
@@ -46,11 +47,13 @@ func (f *Formatter) FormatDeployment(
 	deployedAt time.Time,
 	commits []storage.CommitInfo,
 ) (integrations.DevLakeCICDDeployment, bool) {
-	deploymentID := appInfo.Revision
-	repoURL := f.getRepoURLFromHistory(app, deploymentID)
-	infraCommitMsg := f.getCommitMessageFromGitHub(deploymentID)
+	// Create unique deployment ID by combining revision and cluster
+	// This ensures each cluster deployment is tracked separately
+	deploymentID := fmt.Sprintf("%s:%s", appInfo.Revision, appInfo.Cluster)
+	repoURL := f.getRepoURLFromHistory(app, appInfo.Revision)
+	infraCommitMsg := f.getCommitMessageFromGitHub(appInfo.Revision)
 
-	devlakeCommits := f.createDevLakeCommits(commits, deployedAt, repoURL, deploymentID, infraCommitMsg, appInfo.Component)
+	devlakeCommits := f.createDevLakeCommits(commits, deployedAt, repoURL, appInfo.Revision, infraCommitMsg, appInfo.Component)
 
 	// If no commits to include, return empty deployment and false
 	if len(devlakeCommits) == 0 {
@@ -64,19 +67,26 @@ func (f *Formatter) FormatDeployment(
 		componentName = app.Name
 	}
 
+	// Use the environment from appInfo (extracted from source path)
+	environment := appInfo.Environment
+	if environment == "" {
+		environment = "PRODUCTION" // Fallback
+	}
+
 	// Create a meaningful DisplayTitle for AI agents with structured information
-	// Format: "ArgoCD Deployment | Component: {component} | Namespace: {namespace} | Revision: {revision} | Status: {result} | Deployed: {timestamp}"
+	// Format: "ArgoCD Deployment | Component: {component} | Cluster: {cluster} | Environment: {env} | Revision: {revision} | Status: {result} | Deployed: {timestamp}"
 	namespace := appInfo.Namespace
 	if namespace == "" {
 		namespace = app.Namespace
 	}
-	displayTitle := fmt.Sprintf("ArgoCD Deployment | Component: %s | Namespace: %s | Revision: %s | Status: %s | Deployed: %s",
+	displayTitle := fmt.Sprintf("ArgoCD Deployment | Component: %s | Cluster: %s | Environment: %s | Revision: %s | Status: %s | Deployed: %s",
 		componentName,
-		namespace,
-		deploymentID,
+		appInfo.Cluster,
+		environment,
+		appInfo.Revision,
 		result,
 		deployedAt.Format("2006-01-02 15:04:05 MST"))
-	name := fmt.Sprintf("deploy to production %s", deploymentID)
+	name := fmt.Sprintf("deploy to %s %s", strings.ToLower(environment), appInfo.Revision)
 
 	// Calculate proper timeline
 	startedDate, finishedDate := f.calculateTimeline(devlakeCommits, deployedAt)
@@ -94,7 +104,7 @@ func (f *Formatter) FormatDeployment(
 		CreatedDate:       &createdDateStr,
 		StartedDate:       startedDateStr,
 		FinishedDate:      finishedDateStr,
-		Environment:       "PRODUCTION",
+		Environment:       environment,
 		Result:            result,
 		DisplayTitle:      &displayTitle,
 		Name:              &name,


### PR DESCRIPTION
…ter-unique

Environment was hardcoded as PRODUCTION for all deployments, causing staging deployments to be incorrectly labeled. Now extracted from the ArgoCD source path (e.g., components/project-controller/production/).

Deployment IDs now include the cluster name (revision:cluster) to prevent different cluster deployments from colliding in DevLake.