### PR TITLE
fix: update redis image to resolve critical CVEs

### DIFF
--- a/manifests/local/README.md
+++ b/manifests/local/README.md
@@ -7,7 +7,7 @@ This directory contains the OpenShift manifests for deploying the DORA Metrics a
 - OpenShift cluster with appropriate permissions
 - `oc` CLI tool installed and configured
 - Access to the `quay.io/redhat-appstudio/dora-metrics` container image
-- Access to the `redis:7.0-alpine` container image (used as sidecar)
+- Access to the `redis:8-alpine` container image (used as sidecar)
 
 ## Deployment
 

--- a/manifests/local/deployment.yaml
+++ b/manifests/local/deployment.yaml
@@ -99,7 +99,7 @@ spec:
           mountPath: /app/configs
           readOnly: true
       - name: redis
-        image: redis:7.0-alpine
+        image: redis:8-alpine
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379

--- a/manifests/production/deployment.yaml
+++ b/manifests/production/deployment.yaml
@@ -99,7 +99,7 @@ spec:
           mountPath: /app/configs
           readOnly: true
       - name: redis
-        image: redis:7.0-alpine
+        image: redis:8-alpine
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379


### PR DESCRIPTION
Updates the redis image from 7.0 to 8, resolving the CVEs

Jira: https://issues.redhat.com/browse/KONFLUX-10963